### PR TITLE
Fix runtime delays smoke detec app

### DIFF
--- a/docker-compose-smoke-overlay.yaml
+++ b/docker-compose-smoke-overlay.yaml
@@ -10,6 +10,7 @@ services:
       - MODEL_FILE=model.onnx
       - MODEL_TYPE=smokeynet
       - CAMERA_TYPE=hpwren
+    command: [-delay, "1.0"]
     volumes:
       - ${PWD}/pywaggle-logs:/src/pywaggle-logs
 

--- a/src/main/java/com/rutgers/Examples/SmokeConsumer.java
+++ b/src/main/java/com/rutgers/Examples/SmokeConsumer.java
@@ -74,7 +74,7 @@ public class SmokeConsumer {
      */
     public static void main(String[] args) throws UnknownHostException, ClassNotFoundException {
         try {
-        	
+            Thread.sleep(10000);
         	if(args.length == 0) {
     	        System.out.println("Need to specify the consumer property file!!");
     	        System.exit(0);

--- a/src/main/java/com/rutgers/Examples/SmokePublisher.java
+++ b/src/main/java/com/rutgers/Examples/SmokePublisher.java
@@ -72,6 +72,7 @@ public class SmokePublisher {
      */
     public static void main(String[] args) throws UnknownHostException, ClassNotFoundException, ParseException {
         try {
+            Thread.sleep(10000);
         	if(args.length == 0) {
     	        System.out.println("Need to specify input files.");
     	        System.exit(0);


### PR DESCRIPTION
- change smoke detector model delay to 1 sec from 1 min (only for runtime demonstrations)
- add sleep delays to consumer and publisher to allow smoke detector to finish first